### PR TITLE
Add minimum browser support

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+picocolors.browser.*

--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
     },
     "./package.json": "./package.json"
   },
+  "browser": {
+    "./picocolors.js": "./picocolors.browser.js",
+    "./picocolors.cjs": "./picocolors.browser.cjs"
+  },
   "sideEffects": false,
   "description": "The tiniest and the fastest coloring library ever",
   "scripts": {

--- a/picocolors.browser.cjs
+++ b/picocolors.browser.cjs
@@ -1,0 +1,2 @@
+function x(v) { return v; }
+module.exports = { isColorSupported: false, reset: x, bold: x, dim: x, italic: x, underline: x, inverse: x, hidden: x, strikethrough: x, black: x, red: x, green: x, yellow: x, blue: x, magenta: x, cyan: x, white: x, gray: x, bgBlack: x, bgRed: x, bgGreen: x, bgYellow: x, bgBlue: x, bgMagenta: x, bgCyan: x, bgWhite: x };

--- a/picocolors.browser.cjs
+++ b/picocolors.browser.cjs
@@ -1,2 +1,2 @@
-function x(v) { return v; }
-module.exports = { isColorSupported: false, reset: x, bold: x, dim: x, italic: x, underline: x, inverse: x, hidden: x, strikethrough: x, black: x, red: x, green: x, yellow: x, blue: x, magenta: x, cyan: x, white: x, gray: x, bgBlack: x, bgRed: x, bgGreen: x, bgYellow: x, bgBlue: x, bgMagenta: x, bgCyan: x, bgWhite: x };
+function x(v){return v;}
+module.exports={isColorSupported:false,reset:x,bold:x,dim:x,italic:x,underline:x,inverse:x,hidden:x,strikethrough:x,black:x,red:x,green:x,yellow:x,blue:x,magenta:x,cyan:x,white:x,gray:x,bgBlack:x,bgRed:x,bgGreen:x,bgYellow:x,bgBlue:x,bgMagenta:x,bgCyan:x,bgWhite:x};

--- a/picocolors.browser.js
+++ b/picocolors.browser.js
@@ -1,0 +1,3 @@
+function x(v) { return v; }
+let isColorSupported = false;
+export { isColorSupported, x as reset, x as bold, x as dim, x as italic, x as underline, x as inverse, x as hidden, x as strikethrough, x as black, x as red, x as green, x as yellow, x as blue, x as magenta, x as cyan, x as white, x as gray, x as bgBlack, x as bgRed, x as bgGreen, x as bgYellow, x as bgBlue, x as bgMagenta, x as bgCyan, x as bgWhite };

--- a/picocolors.browser.js
+++ b/picocolors.browser.js
@@ -1,3 +1,2 @@
-function x(v) { return v; }
-let isColorSupported = false;
-export { isColorSupported, x as reset, x as bold, x as dim, x as italic, x as underline, x as inverse, x as hidden, x as strikethrough, x as black, x as red, x as green, x as yellow, x as blue, x as magenta, x as cyan, x as white, x as gray, x as bgBlack, x as bgRed, x as bgGreen, x as bgYellow, x as bgBlue, x as bgMagenta, x as bgCyan, x as bgWhite };
+let x=(v)=>v,f=false;
+export {f as isColorSupported,x as reset,x as bold,x as dim,x as italic,x as underline,x as inverse,x as hidden,x as strikethrough,x as black,x as red,x as green,x as yellow,x as blue,x as magenta,x as cyan,x as white,x as gray,x as bgBlack,x as bgRed,x as bgGreen,x as bgYellow,x as bgBlue,x as bgMagenta,x as bgCyan,x as bgWhite};


### PR DESCRIPTION
Per #1, there are cases where a node module can be bundled to be used in browser environment. The lib uses `tty` node module which is not accessible in browsers and there simply not so much the lib can do to make text in browsers colored. Thus, we introduce stubs, that make it possible to bundle the lib without any issues.

I explicitly made it so the code in stubs is "minified". We're not going to update these files often (ever?) so no need to format them properly. This should shove off some bytes from the NPM package.
