### PR TITLE
Use clean-publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,9 +35,13 @@
   "repository": "alexeyraspopov/picocolors",
   "license": "ISC",
   "devDependencies": {
+    "clean-publish": "^3.0.3",
     "prettier": "^2.4.1"
   },
   "prettier": {
     "printWidth": 100
+  },
+  "clean-publish": {
+     "cleanDocs": true
   }
 }


### PR DESCRIPTION
[`clean-publish`](https://github.com/shashkovdanil/clean-publish) is a tool which allows your package to become smaller than 10 KB.

1. It cleans development configs from `package.json`. Not a big thing for this package, but nice to have for perfectionism.
2. It can clean `README.md` in npm package by keeping only top section (which is still important for `npm.js/package/picocolors` page).