### PR TITLE
Add explicit type definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "main": "./picocolors.cjs",
   "module": "./picocolors.js",
+  "types": "./picocolors.d.ts",
   "exports": {
     ".": {
       "require": "./picocolors.cjs",


### PR DESCRIPTION
Right now, VS Code do not see Picocolors types on `Cmd + Click`.

Unfortunately, there are plenty of services which do not see types without explicit definition.