### PR TITLE
Remove useless `!~index` check

### DIFF
--- a/picocolors.cjs
+++ b/picocolors.cjs
@@ -10,12 +10,8 @@ let isColorSupported =
 
 function formatter(open, close, replace = open) {
   return isColorSupported
-    ? (string) => {
-        let index = string.indexOf(close, open.length);
-        return !~index
-          ? open + string + close
-          : open + replaceClose(string, close, replace, index) + close;
-      }
+    ? (string) =>
+        open + replaceClose(string, close, replace, string.indexOf(close, open.length)) + close
     : (string) => string;
 }
 

--- a/picocolors.js
+++ b/picocolors.js
@@ -10,12 +10,8 @@ export let isColorSupported =
 
 function formatter(open, close, replace = open) {
   return isColorSupported
-    ? (string) => {
-        let index = string.indexOf(close, open.length);
-        return !~index
-          ? open + string + close
-          : open + replaceClose(string, close, replace, index) + close;
-      }
+    ? (string) =>
+        open + replaceClose(string, close, replace, string.indexOf(close, open.length)) + close
     : (string) => string;
 }
 


### PR DESCRIPTION
Removes an extra `!~index` check but calls `replaceClose` every time. I get mixed results depending on the run order.

```diff
+picocolors_ × 1,092,646 ops/sec
picocolors × 1,081,848 ops/sec
```
```diff
picocolors × 1,105,993 ops/sec
+picocolors_ × 1,099,502 ops/sec
```