### PR TITLE
Replace isatty(1) with process.stdout.isTTY

### DIFF
--- a/picocolors.cjs
+++ b/picocolors.cjs
@@ -1,11 +1,9 @@
-let tty = require("tty");
-
 let isColorSupported =
   !("NO_COLOR" in process.env || process.argv.includes("--no-color")) &&
   ("FORCE_COLOR" in process.env ||
     process.argv.includes("--color") ||
     process.platform === "win32" ||
-    (tty.isatty(1) && process.env.TERM !== "dumb") ||
+    (process.stdout.isTTY && process.env.TERM !== "dumb") ||
     "CI" in process.env);
 
 function formatter(open, close, replace = open) {

--- a/picocolors.js
+++ b/picocolors.js
@@ -1,11 +1,9 @@
-import tty from "tty";
-
 export let isColorSupported =
   !("NO_COLOR" in process.env || process.argv.includes("--no-color")) &&
   ("FORCE_COLOR" in process.env ||
     process.argv.includes("--color") ||
     process.platform === "win32" ||
-    (tty.isatty(1) && process.env.TERM !== "dumb") ||
+    (process.stdout.isTTY && process.env.TERM !== "dumb") ||
     "CI" in process.env);
 
 function formatter(open, close, replace = open) {


### PR DESCRIPTION
Replaced `tty.isatty(1)` with `process.stdout.isTTY`

This change slightly decreases the module loading time, as measured in the `nanocolors` repo: `0.515 ms` -> `0.502ms` (best of the 100 measurements)

----

`process.stdout.isTTY` means exactly the same as `tty.isatty(1)` and is supported since Node v0.5.8