### PR TITLE
Add benchmarks

### DIFF
--- a/benchmarks/complex.js
+++ b/benchmarks/complex.js
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+
+// Benchmark results are unstable. To have more stable results:
+// 1. Restart OS. Do not run any applications. Put power cable to laptop.
+// 2. Run tests 5 times.
+// 3. Took the best result for each candidate.
+
+import benchmark from "benchmark";
+import * as colorette from "colorette";
+import kleur from "kleur";
+import * as kleurColors from "kleur/colors";
+import chalk from "chalk";
+import ansi from "ansi-colors";
+import cliColor from "cli-color";
+import * as pen from "felt-pen";
+import * as picocolors from "../picocolors.js";
+import * as nanocolors from "nanocolors";
+
+function formatNumber(number) {
+  return String(number)
+    .replace(/\d{3}$/, ",$&")
+    .replace(/^(\d|\d\d)(\d{3},)/, "$1,$2");
+}
+
+const suite = new benchmark.Suite();
+let out;
+
+let index = 1e8;
+
+suite
+  .add("chalk", () => {
+    out =
+      chalk.bgRed.black(" ERROR ") +
+      chalk.red(
+        " Add plugin " + chalk.yellow("name") + " to use time limit with " + chalk.yellow(++index)
+      );
+  })
+  .add("cli-color", () => {
+    out =
+      cliColor.bgRed.black(" ERROR ") +
+      cliColor.red(
+        " Add plugin " +
+          cliColor.yellow("name") +
+          " to use time limit with " +
+          cliColor.yellow(++index)
+      );
+  })
+  .add("ansi-colors", () => {
+    out =
+      ansi.bgRed.black(" ERROR ") +
+      ansi.red(
+        " Add plugin " + ansi.yellow("name") + " to use time limit with " + ansi.yellow(++index)
+      );
+  })
+  .add("kleur", () => {
+    out =
+      kleur.bgRed().black(" ERROR ") +
+      kleur.red(
+        " Add plugin " + kleur.yellow("name") + " to use time limit with " + kleur.yellow(++index)
+      );
+  })
+  .add("kleur/colors", () => {
+    out =
+      kleurColors.bgRed(kleurColors.black(" ERROR ")) +
+      kleurColors.red(
+        " Add plugin " +
+          kleurColors.yellow("name") +
+          " to use time limit with " +
+          kleurColors.yellow(++index)
+      );
+  })
+  .add("colorette", () => {
+    out =
+      colorette.bgRed(colorette.black(" ERROR ")) +
+      colorette.red(
+        " Add plugin " +
+          colorette.yellow("name") +
+          " to use time limit with " +
+          colorette.yellow(++index)
+      );
+  })
+  .add("felt-pen", () => {
+    out =
+      pen.Red(" ERROR ") +
+      pen.red(
+        " Add plugin " + pen.yellow("name") + " to use time limit with " + pen.yellow(++index)
+      );
+  })
+  .add("nanocolors", () => {
+    out =
+      nanocolors.bgRed(nanocolors.black(" ERROR ")) +
+      nanocolors.red(
+        " Add plugin " +
+          nanocolors.yellow("name") +
+          " to use time limit with " +
+          nanocolors.yellow(++index)
+      );
+  })
+  .add("picocolors", () => {
+    out =
+      picocolors.bgRed(picocolors.black(" ERROR ")) +
+      picocolors.red(
+        " Add plugin " +
+          picocolors.yellow("name") +
+          " to use time limit with " +
+          picocolors.yellow(`${++index}`)
+      );
+  })
+  .on("cycle", (event) => {
+    const prefix = event.target.name === "picocolors" ? "+ " : "  ";
+    const name = event.target.name.padEnd("kleur/colors  ".length);
+    const hz = formatNumber(event.target.hz.toFixed(0)).padStart(10);
+    process.stdout.write(`${prefix}${name}${picocolors.bold(hz)} ops/sec\n`);
+  })
+  .on("error", (event) => {
+    process.stderr.write(picocolors.red(event.target.error.toString()) + "\n");
+  })
+  .run();

--- a/benchmarks/loading-runner.cjs
+++ b/benchmarks/loading-runner.cjs
@@ -1,0 +1,43 @@
+const { performance } = require("perf_hooks");
+
+let before;
+function showTime(name) {
+  let after = performance.now();
+  process.stdout.write(name + " " + (after - before) + "\n");
+}
+
+before = performance.now();
+let chalk = require("chalk");
+showTime("chalk");
+
+before = performance.now();
+let cliColor = require("cli-color");
+showTime("cli-color");
+
+before = performance.now();
+let ansi = require("ansi-colors");
+showTime("ansi-colors");
+
+before = performance.now();
+let kleur = require("kleur");
+showTime("kleur");
+
+before = performance.now();
+let kleurColors = require("kleur/colors");
+showTime("kleur/colors");
+
+before = performance.now();
+let colorette = require("colorette");
+showTime("colorette");
+
+before = performance.now();
+let pen = require("felt-pen");
+showTime("felt-pen");
+
+before = performance.now();
+let nanocolors = require("nanocolors");
+showTime("nanocolors");
+
+before = performance.now();
+let picocolors = require("../picocolors.cjs");
+showTime("picocolors");

--- a/benchmarks/loading.js
+++ b/benchmarks/loading.js
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+import { execSync } from "child_process";
+
+const RUNS = 50;
+
+const results = {};
+
+for (let i = 0; i < RUNS; i++) {
+  const output = execSync("node ./tests/loading-runner.cjs").toString();
+  output
+    .trim()
+    .split("\n")
+    .forEach((line) => {
+      let [name, result] = line.split(" ");
+      results[name] = (results[name] || 0) + parseFloat(result);
+    });
+}
+
+for (const name in results) {
+  const prefix = name === "picocolors" ? "+ " : "  ";
+  const title = name.padEnd("kleur/colors  ".length);
+  const time = (Math.round((1000 * results[name]) / RUNS) / 1000)
+    .toString()
+    .replace(/\.\d$/, "$&00")
+    .replace(/\.\d\d$/, "$&0");
+  process.stdout.write(prefix + title + "\x1B[1m" + time.padStart(6) + "\x1B[22m ms\n");
+}

--- a/benchmarks/simple.js
+++ b/benchmarks/simple.js
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+
+// Benchmark results are unstable. To have more stable results:
+// 1. Restart OS. Do not run any applications. Put power cable to laptop.
+// 2. Run tests 5 times.
+// 3. Took the best result for each candidate.
+
+import benchmark from "benchmark";
+import * as colorette from "colorette";
+import kleur from "kleur";
+import * as kleurColors from "kleur/colors";
+import chalk from "chalk";
+import ansi from "ansi-colors";
+import cliColor from "cli-color";
+import * as pen from "felt-pen";
+import * as picocolors from "../picocolors.js";
+import * as nanocolors from "nanocolors";
+
+function formatNumber(number) {
+  return String(number)
+    .replace(/\d{3}$/, ",$&")
+    .replace(/^(\d|\d\d)(\d{3},)/, "$1,$2");
+}
+
+const suite = new benchmark.Suite();
+let out;
+
+suite
+  .add("chalk", () => {
+    out = chalk.bgRed.black(" ERROR ") + chalk.red(" Add plugin to use time limit");
+  })
+  .add("cli-color", () => {
+    out = cliColor.bgRed.black(" ERROR ") + cliColor.red(" Add plugin to use time limit");
+  })
+  .add("ansi-colors", () => {
+    out = ansi.bgRed.black(" ERROR ") + ansi.red(" Add plugin to use time limit");
+  })
+  .add("kleur", () => {
+    out = kleur.bgRed().black(" ERROR ") + kleur.red(" Add plugin to use time limit");
+  })
+  .add("kleur/colors", () => {
+    out =
+      kleurColors.bgRed(kleurColors.black(" ERROR ")) +
+      kleurColors.red(" Add plugin to use time limit");
+  })
+  .add("colorette", () => {
+    out =
+      colorette.bgRed(colorette.black(" ERROR ")) + colorette.red(" Add plugin to use time limit");
+  })
+  .add("felt-pen", () => {
+    out = pen.Red(" ERROR ") + pen.red(" Add plugin to use time limit");
+  })
+  .add("nanocolors", () => {
+    out =
+      nanocolors.bgRed(nanocolors.black(" ERROR ")) +
+      nanocolors.red(" Add plugin to use time limit");
+  })
+  .add("picocolors", () => {
+    out =
+      picocolors.bgRed(picocolors.black(" ERROR ")) +
+      picocolors.red(" Add plugin to use time limit");
+  })
+  .on("cycle", (event) => {
+    const prefix = event.target.name === "picocolors" ? "+ " : "  ";
+    const name = event.target.name.padEnd("kleur/colors  ".length);
+    const hz = formatNumber(event.target.hz.toFixed(0)).padStart(10);
+    process.stdout.write(`${prefix}${name}${picocolors.bold(hz)} ops/sec\n`);
+  })
+  .on("error", (event) => {
+    process.stderr.write(picocolors.red(event.target.error.toString()) + "\n");
+  })
+  .run();

--- a/benchmarks/size.js
+++ b/benchmarks/size.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+
+import { get } from "https";
+
+import { bold, gray } from "../picocolors.js";
+
+async function getJSON(url) {
+  return new Promise((resolve) => {
+    get(url, (res) => {
+      let text = "";
+      res.on("data", (chunk) => {
+        text += chunk;
+      });
+      res.on("end", () => {
+        resolve(JSON.parse(text));
+      });
+    });
+  });
+}
+
+async function benchmark(lib) {
+  let data = await getJSON(`https://packagephobia.com/v2/api.json?p=${lib}`);
+  let size = data.install.bytes;
+  process.stdout.write(
+    lib.padEnd("ansi-colors  ".length) +
+      bold(
+        Math.round(size / 1024)
+          .toString()
+          .padStart(4)
+      ) +
+      " kB\n"
+  );
+}
+
+async function start() {
+  process.stdout.write(gray("Data from packagephobia.com\n"));
+  await benchmark("  chalk");
+  await benchmark("  cli-color");
+  await benchmark("  ansi-colors");
+  await benchmark("  kleur");
+  await benchmark("  colorette");
+  await benchmark("  felt-pen");
+  await benchmark("  nanocolors");
+  await benchmark("+ picocolors");
+}
+
+start();

--- a/package.json
+++ b/package.json
@@ -36,6 +36,14 @@
   "repository": "alexeyraspopov/picocolors",
   "license": "ISC",
   "devDependencies": {
+    "ansi-colors": "^4.1.1",
+    "benchmark": "^2.1.4",
+    "chalk": "^4.1.2",
+    "cli-color": "^2.0.0",
+    "colorette": "^2.0.12",
+    "felt-pen": "^2.0.0",
+    "kleur": "^4.1.4",
+    "nanocolors": "^0.2.12",
     "prettier": "^2.4.1"
   },
   "prettier": {


### PR DESCRIPTION
I copied size, loading, simple and complex benchmarks from Nano Colors and improve it a little:

1. Added `+ ` to `picocolors` line to use result in `diff` code block.
2. The loading benchmark runs 50 to make results more stable.
3. Simple & complex benchmarks now use real string from Size Limit. Short strings give a wrong synthetic results and very rare in real use cases.

I do not change docs because maintainer should use own machine to get results.