### PR TITLE
Implement createColors() api

### DIFF
--- a/colors.js
+++ b/colors.js
@@ -1,0 +1,13 @@
+import * as pc from "./picocolors.js";
+
+let empty = Object.keys(pc).reduce((api, k) => {
+	return Object.assign(api, { [k]: k === "isColorSupported" ? false : noop });
+}, {});
+
+export function createColors(enabled = pc.isColorSupported) {
+	return enabled ? pc : empty;
+}
+
+function noop(v) {
+	return v;
+}


### PR DESCRIPTION
@ai, not quite sure if it fits the use case you described in https://github.com/alexeyraspopov/picocolors/issues/4 but this is one of my ideas for such feature. At least this seems to be the same mechanism `nanocolors` implements. The reason I was hesitant about this feature is the fact how simple it can be implemented in the user space. But since this implementation doesn't take much space, we can probably ship it as `picocolors/factory` (or something like this) so the few who need it can just use it and the rest won't need to import it. Thoughts?