### PR TITLE
Remove fen-pen because of different API and simplify fimple benchmark

### DIFF
--- a/benchmarks/complex.js
+++ b/benchmarks/complex.js
@@ -95,7 +95,7 @@ suite
         " Add plugin " +
           picocolors.yellow("name") +
           " to use time limit with " +
-          picocolors.yellow(++index)
+          picocolors.yellow(`${++index}`)
       );
   })
   .on("cycle", (event) => {
@@ -106,5 +106,6 @@ suite
   })
   .on("error", (event) => {
     process.stderr.write(picocolors.red(event.target.error.toString()) + "\n");
+    process.exit(1);
   })
   .run();

--- a/benchmarks/complex.js
+++ b/benchmarks/complex.js
@@ -12,7 +12,6 @@ import * as kleurColors from "kleur/colors";
 import chalk from "chalk";
 import ansi from "ansi-colors";
 import cliColor from "cli-color";
-import * as pen from "felt-pen";
 import * as picocolors from "../picocolors.js";
 import * as nanocolors from "nanocolors";
 
@@ -79,13 +78,6 @@ suite
           colorette.yellow(++index)
       );
   })
-  .add("felt-pen", () => {
-    out =
-      pen.Red(" ERROR ") +
-      pen.red(
-        " Add plugin " + pen.yellow("name") + " to use time limit with " + pen.yellow(++index)
-      );
-  })
   .add("nanocolors", () => {
     out =
       nanocolors.bgRed(nanocolors.black(" ERROR ")) +
@@ -103,7 +95,7 @@ suite
         " Add plugin " +
           picocolors.yellow("name") +
           " to use time limit with " +
-          picocolors.yellow(`${++index}`)
+          picocolors.yellow(++index)
       );
   })
   .on("cycle", (event) => {

--- a/benchmarks/loading-runner.cjs
+++ b/benchmarks/loading-runner.cjs
@@ -31,10 +31,6 @@ let colorette = require("colorette");
 showTime("colorette");
 
 before = performance.now();
-let pen = require("felt-pen");
-showTime("felt-pen");
-
-before = performance.now();
 let nanocolors = require("nanocolors");
 showTime("nanocolors");
 

--- a/benchmarks/simple.js
+++ b/benchmarks/simple.js
@@ -12,7 +12,6 @@ import * as kleurColors from "kleur/colors";
 import chalk from "chalk";
 import ansi from "ansi-colors";
 import cliColor from "cli-color";
-import * as pen from "felt-pen";
 import * as picocolors from "../picocolors.js";
 import * as nanocolors from "nanocolors";
 
@@ -27,7 +26,6 @@ console.log(kleur.green("kleur"));
 console.log(chalk.green("chalk"));
 console.log(ansi.green("ansi"));
 console.log(cliColor.green("cliColor"));
-console.log(pen.green("pen"));
 console.log(picocolors.green("picocolors"));
 console.log(nanocolors.green("nanocolors"));
 
@@ -36,38 +34,28 @@ let out;
 
 suite
   .add("chalk", () => {
-    out = chalk.bgRed.black(" ERROR ") + chalk.red(" Add plugin to use time limit");
+    out = chalk.red("Add plugin to use time limit");
   })
   .add("cli-color", () => {
-    out = cliColor.bgRed.black(" ERROR ") + cliColor.red(" Add plugin to use time limit");
+    out = cliColor.red("Add plugin to use time limit");
   })
   .add("ansi-colors", () => {
-    out = ansi.bgRed.black(" ERROR ") + ansi.red(" Add plugin to use time limit");
+    out = ansi.red("Add plugin to use time limit");
   })
   .add("kleur", () => {
-    out = kleur.bgRed().black(" ERROR ") + kleur.red(" Add plugin to use time limit");
+    out = kleur.red("Add plugin to use time limit");
   })
   .add("kleur/colors", () => {
-    out =
-      kleurColors.bgRed(kleurColors.black(" ERROR ")) +
-      kleurColors.red(" Add plugin to use time limit");
+    out = kleurColors.red("Add plugin to use time limit");
   })
   .add("colorette", () => {
-    out =
-      colorette.bgRed(colorette.black(" ERROR ")) + colorette.red(" Add plugin to use time limit");
-  })
-  .add("felt-pen", () => {
-    out = pen.Red(" ERROR ") + pen.red(" Add plugin to use time limit");
+    out = colorette.red("Add plugin to use time limit");
   })
   .add("nanocolors", () => {
-    out =
-      nanocolors.bgRed(nanocolors.black(" ERROR ")) +
-      nanocolors.red(" Add plugin to use time limit");
+    out = nanocolors.red("Add plugin to use time limit");
   })
   .add("picocolors", () => {
-    out =
-      picocolors.bgRed(picocolors.black(" ERROR ")) +
-      picocolors.red(" Add plugin to use time limit");
+    out = picocolors.red("Add plugin to use time limit");
   })
   .on("cycle", (event) => {
     const prefix = event.target.name === "picocolors" ? "+ " : "  ";

--- a/benchmarks/simple.js
+++ b/benchmarks/simple.js
@@ -65,5 +65,6 @@ suite
   })
   .on("error", (event) => {
     process.stderr.write(picocolors.red(event.target.error.toString()) + "\n");
+    process.exit(1);
   })
   .run();

--- a/benchmarks/size.js
+++ b/benchmarks/size.js
@@ -39,7 +39,6 @@ async function start() {
   await benchmark("  ansi-colors");
   await benchmark("  kleur");
   await benchmark("  colorette");
-  await benchmark("  felt-pen");
   await benchmark("  nanocolors");
   await benchmark("+ picocolors");
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "chalk": "^4.1.2",
     "cli-color": "^2.0.0",
     "colorette": "^2.0.12",
-    "felt-pen": "^2.0.0",
     "kleur": "^4.1.4",
     "nanocolors": "^0.2.12",
     "prettier": "^2.4.1"


### PR DESCRIPTION
I removed `fen-pen` from benhcmark because:

1. Tool API and output is different
2. Color auto-detection will not work in CI making it is hard to test benchmark in CI.
3. Results are not the best

I also removed `[ WARN ]` prefix from `simple` benchmark. This pattern in rare in real use cases. Let’s make simple benchmark simple.