### PR TITLE
Fix React Native support

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "./picocolors.js": "./picocolors.browser.js",
     "./picocolors.cjs": "./picocolors.browser.cjs"
   },
+  "react-native": "picocolors.browser.js",
   "sideEffects": false,
   "description": "The tiniest and the fastest coloring library ever",
   "scripts": {


### PR DESCRIPTION
100% universal packages in JS ecosystem is hard 😓

Here is a reference issue, which was fixed with the same fix in Nano Colors:
https://github.com/postcss/postcss/issues/1639