### PR TITLE
Add small strings to benchmark

### DIFF
--- a/benchmarks/complex.js
+++ b/benchmarks/complex.js
@@ -29,6 +29,9 @@ let index = 1e8;
 suite
 	.add("chalk", () => {
 		out =
+			chalk.red('.') +
+			chalk.yellow('.') +
+			chalk.green('.') +
 			chalk.bgRed.black(" ERROR ") +
 			chalk.red(
 				" Add plugin " + chalk.yellow("name") + " to use time limit with " + chalk.yellow(++index)
@@ -36,6 +39,9 @@ suite
 	})
 	.add("cli-color", () => {
 		out =
+		cliColor.red('.') +
+		cliColor.yellow('.') +
+		cliColor.green('.') +
 			cliColor.bgRed.black(" ERROR ") +
 			cliColor.red(
 				" Add plugin " +
@@ -46,6 +52,9 @@ suite
 	})
 	.add("ansi-colors", () => {
 		out =
+		ansi.red('.') +
+		ansi.yellow('.') +
+		ansi.green('.') +
 			ansi.bgRed.black(" ERROR ") +
 			ansi.red(
 				" Add plugin " + ansi.yellow("name") + " to use time limit with " + ansi.yellow(++index)
@@ -53,6 +62,9 @@ suite
 	})
 	.add("kleur", () => {
 		out =
+		kleur.red('.') +
+		kleur.yellow('.') +
+		kleur.green('.') +
 			kleur.bgRed().black(" ERROR ") +
 			kleur.red(
 				" Add plugin " + kleur.yellow("name") + " to use time limit with " + kleur.yellow(++index)
@@ -60,6 +72,9 @@ suite
 	})
 	.add("kleur/colors", () => {
 		out =
+		kleurColors.red('.') +
+		kleurColors.yellow('.') +
+		kleurColors.green('.') +
 			kleurColors.bgRed(kleurColors.black(" ERROR ")) +
 			kleurColors.red(
 				" Add plugin " +
@@ -70,6 +85,9 @@ suite
 	})
 	.add("colorette", () => {
 		out =
+		colorette.red('.') +
+		colorette.yellow('.') +
+		colorette.green('.') +
 			colorette.bgRed(colorette.black(" ERROR ")) +
 			colorette.red(
 				" Add plugin " +
@@ -80,6 +98,9 @@ suite
 	})
 	.add("nanocolors", () => {
 		out =
+		nanocolors.red('.') +
+		nanocolors.yellow('.') +
+		nanocolors.green('.') +
 			nanocolors.bgRed(nanocolors.black(" ERROR ")) +
 			nanocolors.red(
 				" Add plugin " +
@@ -90,6 +111,9 @@ suite
 	})
 	.add("picocolors", () => {
 		out =
+		picocolors.red('.') +
+		picocolors.yellow('.') +
+		picocolors.green('.') +
 			picocolors.bgRed(picocolors.black(" ERROR ")) +
 			picocolors.red(
 				" Add plugin " +


### PR DESCRIPTION
Current color library has optimizations for small string. Small strings are also widely used in real use cases.

So, I think we should add them to get more real benchmark.