### PR TITLE
Fix type definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,4 @@
 {
-<<<<<<< HEAD
   "name": "picocolors",
   "version": "0.2.0",
   "main": "./picocolors.js",
@@ -46,51 +45,4 @@
   "clean-publish": {
     "cleanDocs": true
   }
-=======
-	"name": "picocolors",
-	"version": "0.2.0",
-	"main": "./picocolors.js",
-	"types": "./picocolors.d.ts",
-	"browser": {
-		"./picocolors.js": "./picocolors.browser.js"
-	},
-	"sideEffects": false,
-	"description": "The tiniest and the fastest coloring library ever",
-	"scripts": {
-		"test": "node tests/test.js"
-	},
-	"files": [
-		"picocolors.*",
-		"types.ts"
-	],
-	"keywords": [
-		"terminal",
-		"colors",
-		"formatting",
-		"cli",
-		"console"
-	],
-	"author": "Alexey Raspopov",
-	"repository": "alexeyraspopov/picocolors",
-	"license": "ISC",
-	"devDependencies": {
-		"ansi-colors": "^4.1.1",
-		"benchmark": "^2.1.4",
-		"chalk": "^4.1.2",
-		"clean-publish": "^3.0.3",
-		"cli-color": "^2.0.0",
-		"colorette": "^2.0.12",
-		"kleur": "^4.1.4",
-		"nanocolors": "^0.2.12",
-		"prettier": "^2.4.1"
-	},
-	"prettier": {
-		"printWidth": 100,
-		"useTabs": true,
-		"tabWidth": 2
-	},
-	"clean-publish": {
-		"cleanDocs": true
-	}
->>>>>>> de8e8e1 (Allow to import Colors and Formatter)
 }

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+<<<<<<< HEAD
   "name": "picocolors",
   "version": "0.2.0",
   "main": "./picocolors.js",
@@ -12,7 +13,8 @@
     "test": "node tests/test.js"
   },
   "files": [
-    "picocolors.*"
+    "picocolors.*",
+    "types.ts"
   ],
   "keywords": [
     "terminal",
@@ -44,4 +46,51 @@
   "clean-publish": {
     "cleanDocs": true
   }
+=======
+	"name": "picocolors",
+	"version": "0.2.0",
+	"main": "./picocolors.js",
+	"types": "./picocolors.d.ts",
+	"browser": {
+		"./picocolors.js": "./picocolors.browser.js"
+	},
+	"sideEffects": false,
+	"description": "The tiniest and the fastest coloring library ever",
+	"scripts": {
+		"test": "node tests/test.js"
+	},
+	"files": [
+		"picocolors.*",
+		"types.ts"
+	],
+	"keywords": [
+		"terminal",
+		"colors",
+		"formatting",
+		"cli",
+		"console"
+	],
+	"author": "Alexey Raspopov",
+	"repository": "alexeyraspopov/picocolors",
+	"license": "ISC",
+	"devDependencies": {
+		"ansi-colors": "^4.1.1",
+		"benchmark": "^2.1.4",
+		"chalk": "^4.1.2",
+		"clean-publish": "^3.0.3",
+		"cli-color": "^2.0.0",
+		"colorette": "^2.0.12",
+		"kleur": "^4.1.4",
+		"nanocolors": "^0.2.12",
+		"prettier": "^2.4.1"
+	},
+	"prettier": {
+		"printWidth": 100,
+		"useTabs": true,
+		"tabWidth": 2
+	},
+	"clean-publish": {
+		"cleanDocs": true
+	}
+>>>>>>> de8e8e1 (Allow to import Colors and Formatter)
 }

--- a/picocolors.d.ts
+++ b/picocolors.d.ts
@@ -1,6 +1,6 @@
-export type Formatter = (input: string | number | null | undefined) => string
+type Formatter = (input: string | number | null | undefined) => string
 
-export interface Colors {
+interface Colors {
 	isColorSupported: boolean
 	reset: Formatter
 	bold: Formatter
@@ -29,4 +29,6 @@ export interface Colors {
 	bgWhite: Formatter
 }
 
-export = Colors & { createColors: (enabled: boolean) => Colors }
+declare const picocolors: Colors & { createColors: (enabled: boolean) => Colors }
+
+export = picocolors

--- a/picocolors.d.ts
+++ b/picocolors.d.ts
@@ -1,33 +1,4 @@
-type Formatter = (input: string | number | null | undefined) => string
-
-interface Colors {
-	isColorSupported: boolean
-	reset: Formatter
-	bold: Formatter
-	dim: Formatter
-	italic: Formatter
-	underline: Formatter
-	inverse: Formatter
-	hidden: Formatter
-	strikethrough: Formatter
-	black: Formatter
-	red: Formatter
-	green: Formatter
-	yellow: Formatter
-	blue: Formatter
-	magenta: Formatter
-	cyan: Formatter
-	white: Formatter
-	gray: Formatter
-	bgBlack: Formatter
-	bgRed: Formatter
-	bgGreen: Formatter
-	bgYellow: Formatter
-	bgBlue: Formatter
-	bgMagenta: Formatter
-	bgCyan: Formatter
-	bgWhite: Formatter
-}
+import { Colors } from "./types"
 
 declare const picocolors: Colors & { createColors: (enabled: boolean) => Colors }
 

--- a/types.ts
+++ b/types.ts
@@ -1,0 +1,30 @@
+export type Formatter = (input: string | number | null | undefined) => string
+
+export interface Colors {
+	isColorSupported: boolean
+	reset: Formatter
+	bold: Formatter
+	dim: Formatter
+	italic: Formatter
+	underline: Formatter
+	inverse: Formatter
+	hidden: Formatter
+	strikethrough: Formatter
+	black: Formatter
+	red: Formatter
+	green: Formatter
+	yellow: Formatter
+	blue: Formatter
+	magenta: Formatter
+	cyan: Formatter
+	white: Formatter
+	gray: Formatter
+	bgBlack: Formatter
+	bgRed: Formatter
+	bgGreen: Formatter
+	bgYellow: Formatter
+	bgBlue: Formatter
+	bgMagenta: Formatter
+	bgCyan: Formatter
+	bgWhite: Formatter
+}


### PR DESCRIPTION
I tried `picocolors` on Autoprefixer and got TS warnings:

```
✖ node_modules/picocolors/picocolors.d.ts:32:1: Type error TS2309
  An export assignment cannot be used in a module with other exported elements.

✖ node_modules/picocolors/picocolors.d.ts:32:10: Type error TS2693
  'Colors' only refers to a type, but is being used as a value here.

✖ node_modules/picocolors/picocolors.d.ts:32:10: Type error TS2714
  The expression of an export assignment must be an identifier or qualified name in an ambient context.

✖ node_modules/picocolors/picocolors.d.ts:32:19: Type error TS2363
  The right-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.

✖ node_modules/picocolors/picocolors.d.ts:32:57: Type error TS2693
  'Colors' only refers to a type, but is being used as a value here.
```

Seems like CJS export is incompatible with named exports, so we can’t export.

My solution is to give another file to import types from:

```ts
import pico from 'picocolors'
import type { Colors } from 'picocolors/types'
```