### PR TITLE
Add terser minification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+picocolors.min.js
+picocolors.browser.min.js

--- a/package.json
+++ b/package.json
@@ -1,48 +1,53 @@
 {
-  "name": "picocolors",
-  "version": "0.2.1",
-  "main": "./picocolors.js",
-  "types": "./picocolors.d.ts",
-  "browser": {
-    "./picocolors.js": "./picocolors.browser.js"
-  },
-  "sideEffects": false,
-  "description": "The tiniest and the fastest library for terminal output formatting with ANSI colors",
-  "scripts": {
-    "test": "node tests/test.js"
-  },
-  "files": [
-    "picocolors.*",
-    "types.ts"
-  ],
-  "keywords": [
-    "terminal",
-    "colors",
-    "formatting",
-    "cli",
-    "console"
-  ],
-  "author": "Alexey Raspopov",
-  "repository": "alexeyraspopov/picocolors",
-  "license": "ISC",
-  "devDependencies": {
-    "ansi-colors": "^4.1.1",
-    "benchmark": "^2.1.4",
-    "chalk": "^4.1.2",
-    "clean-publish": "^3.0.3",
-    "cli-color": "^2.0.0",
-    "colorette": "^2.0.12",
-    "kleur": "^4.1.4",
-    "nanocolors": "^0.2.12",
-    "prettier": "^2.4.1"
-  },
-  "prettier": {
-    "printWidth": 100,
-    "useTabs": true,
-    "tabWidth": 2,
-    "semi": false
-  },
-  "clean-publish": {
-    "cleanDocs": true
-  }
+	"name": "picocolors",
+	"version": "0.2.1",
+	"main": "./picocolors.min.js",
+	"types": "./picocolors.d.ts",
+	"browser": {
+		"./picocolors.js": "./picocolors.browser.min.js"
+	},
+	"sideEffects": false,
+	"description": "The tiniest and the fastest library for terminal output formatting with ANSI colors",
+	"scripts": {
+		"test": "node tests/test.js",
+		"build": "terser --compress --mangle --output picocolors.min.js -- picocolors.js & terser --compress --mangle --output picocolors.browser.min.js -- picocolors.browser.js",
+		"prepublishOnly": "npm run build"
+	},
+	"files": [
+		"picocolors.browser.min.js",
+		"picocolors.min.js",
+		"picocolors.d.ts",
+		"types.ts"
+	],
+	"keywords": [
+		"terminal",
+		"colors",
+		"formatting",
+		"cli",
+		"console"
+	],
+	"author": "Alexey Raspopov",
+	"repository": "alexeyraspopov/picocolors",
+	"license": "ISC",
+	"devDependencies": {
+		"ansi-colors": "^4.1.1",
+		"benchmark": "^2.1.4",
+		"chalk": "^4.1.2",
+		"clean-publish": "^3.0.3",
+		"cli-color": "^2.0.0",
+		"colorette": "^2.0.12",
+		"kleur": "^4.1.4",
+		"nanocolors": "^0.2.12",
+		"prettier": "^2.4.1",
+		"terser": "^5.9.0"
+	},
+	"prettier": {
+		"printWidth": 100,
+		"useTabs": true,
+		"tabWidth": 2,
+		"semi": false
+	},
+	"clean-publish": {
+		"cleanDocs": true
+	}
 }


### PR DESCRIPTION
This PR adds minification powered by Terser, which brings down the size of picocolors.js from 2.58kb to 1.69kb. This also allows for prioritizing readability over size, because Terser minifies everything anyway.