### PR TITLE
Fix enabled param not optional

### DIFF
--- a/picocolors.d.ts
+++ b/picocolors.d.ts
@@ -1,5 +1,5 @@
 import { Colors } from "./types"
 
-declare const picocolors: Colors & { createColors: (enabled: boolean) => Colors }
+declare const picocolors: Colors & { createColors: (enabled?: boolean) => Colors }
 
 export = picocolors


### PR DESCRIPTION
`createColors` passes `isColorSupported` as the [default value](https://github.com/alexeyraspopov/picocolors/blob/d70a62545f994c8df0249fa78038273965aa4faa/picocolors.js#L28), but is not reflected in the exported type.