### PR TITLE
Rework loading benchmark to avoid v8 caching

### DIFF
--- a/benchmarks/loading-runner.js
+++ b/benchmarks/loading-runner.js
@@ -1,39 +1,58 @@
-const { performance } = require("perf_hooks")
+let { performance } = require("perf_hooks")
+let { execSync } = require("child_process")
 
+let path
 let before
+let baseline
 function showTime(name) {
 	let after = performance.now()
-	process.stdout.write(name + " " + (after - before) + "\n")
+	process.stdout.write(name + " " + (after - before - baseline) + "\n")
 }
 
+let startBaseline = performance.now()
+execSync('node --eval ""')
+baseline = performance.now() - startBaseline
+
+path = require.resolve("chalk")
 before = performance.now()
-let chalk = require("chalk")
+load(path)
 showTime("chalk")
 
+path = require.resolve("cli-color")
 before = performance.now()
-let cliColor = require("cli-color")
+load(path)
 showTime("cli-color")
 
+path = require.resolve("ansi-colors")
 before = performance.now()
-let ansi = require("ansi-colors")
+load(path)
 showTime("ansi-colors")
 
+path = require.resolve("kleur")
 before = performance.now()
-let kleur = require("kleur")
+load(path)
 showTime("kleur")
 
+path = require.resolve("kleur/colors")
 before = performance.now()
-let kleurColors = require("kleur/colors")
+load(path)
 showTime("kleur/colors")
 
+path = require.resolve("colorette")
 before = performance.now()
-let colorette = require("colorette")
+load(path)
 showTime("colorette")
 
+path = require.resolve("nanocolors")
 before = performance.now()
-let nanocolors = require("nanocolors")
+load(path)
 showTime("nanocolors")
 
+path = require.resolve("../picocolors.js")
 before = performance.now()
-let picocolors = require("../picocolors.js")
+load(path)
 showTime("picocolors")
+
+function load(path) {
+	execSync(`node --eval 'require("${path}")'`)
+}


### PR DESCRIPTION
Benchmarks are quite random by themselves but there are things we must do to make them close to real numbers. As reported in #35, loading benchmark seems rigged because it uses a single process to test the init time of libraries, thus making the last one to test a clear winner.

In this PR I made it so the libraries are being tested via importing them in a separate node processes. It will take longer to test but the results seem to be more coherent. There is still some deviation but moving `picocolors` up and down does not make significant changes (comparing to the reported issue)

```
$ node benchmarks/loading.js
  chalk          4.687 ms
+ picocolors     0.225 ms
  cli-color     38.682 ms
  ansi-colors    1.056 ms
  kleur          1.641 ms
  kleur/colors   1.618 ms
  colorette      0.969 ms
  nanocolors     0.559 ms
$ node benchmarks/loading.js
+ picocolors     0.685 ms
  chalk          5.954 ms
  cli-color     40.953 ms
  ansi-colors    1.477 ms
  kleur          2.101 ms
  kleur/colors   1.444 ms
  colorette      1.077 ms
  nanocolors     0.704 ms
$ node benchmarks/loading.js
  chalk          5.189 ms
  cli-color     44.259 ms
  ansi-colors    1.162 ms
  kleur          1.619 ms
  kleur/colors   1.640 ms
  colorette      1.045 ms
  nanocolors     0.752 ms
+ picocolors     0.359 ms
```

cc @ai 

Closes #35 