### PR TITLE
Fix color detection in edge runtime

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 18
       - run: npm install
       - name: Ensure color support detection
         run: node tests/environments.js

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -2,9 +2,9 @@ name: Benchmarks
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 env:
   FORCE_COLOR: 3

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -2,9 +2,9 @@ name: Testing
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   modern:
@@ -13,6 +13,7 @@ jobs:
     strategy:
       matrix:
         node-version:
+          - 18
           - 16
           - 14
           - 12

--- a/picocolors.js
+++ b/picocolors.js
@@ -1,12 +1,12 @@
-let tty = require("tty")
-
+let argv = process.argv || [],
+	env = process.env
 let isColorSupported =
-	!("NO_COLOR" in process.env || process.argv.includes("--no-color")) &&
-	("FORCE_COLOR" in process.env ||
-		process.argv.includes("--color") ||
+	!("NO_COLOR" in env || argv.includes("--no-color")) &&
+	("FORCE_COLOR" in env ||
+		argv.includes("--color") ||
 		process.platform === "win32" ||
-		(tty.isatty(1) && process.env.TERM !== "dumb") ||
-		"CI" in process.env)
+		(require != null && require("tty").isatty(1) && env.TERM !== "dumb") ||
+		"CI" in env)
 
 let formatter =
 	(open, close, replace = open) =>

--- a/tests/environments.js
+++ b/tests/environments.js
@@ -46,6 +46,12 @@ test("windows", () => {
 	assert.equal(pc.red("text"), pc.createColors(true).red("text"))
 })
 
+test("edge runtime", () => {
+	let pc = initModuleEnv({ env: { FORCE_COLOR: "1" }, argv: undefined, require: undefined })
+	assert.equal(pc.isColorSupported, true)
+	assert.equal(pc.red("text"), pc.createColors(true).red("text"))
+})
+
 function test(name, fn) {
 	try {
 		fn()
@@ -56,7 +62,7 @@ function test(name, fn) {
 	}
 }
 
-function initModuleEnv({ env, argv = [], platform = "darwin" }) {
+function initModuleEnv({ env, argv = [], platform = "darwin", require = global.require }) {
 	let process = { env, argv, platform }
 	let context = vm.createContext({ require, process, module: { exports: {} } })
 	let script = new vm.Script(source)


### PR DESCRIPTION
Per @brillout's comment here: https://github.com/alexeyraspopov/picocolors/pull/54#issuecomment-1531003517 Edge Runtime has following constraints:

- `require` is `undefined`
- `process.argv` is `undefined`

Here I'm trying to fix this without blowing out the size of the package

`picocolor.js` size goes from `2594B` to `2600B`.

Closes https://github.com/alexeyraspopov/picocolors/pull/54