### PR TITLE
Support named exports in the ESM mode

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -24,6 +24,7 @@ jobs:
       - run: npm run build
       - run: node tests/test.js
       - run: node tests/esm.mjs
+      - run: node tests/types.mjs
   legacy:
     name: Node v${{ matrix.node-version }} (Legacy)
     runs-on: ubuntu-latest

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -15,22 +15,24 @@ jobs:
         node-version:
           - 20
           - 18
-          - 16
-          - 14
-          - 12
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install
+      - run: npm run build
       - run: node tests/test.js
+      - run: node tests/esm.mjs
   legacy:
     name: Node v${{ matrix.node-version }} (Legacy)
     runs-on: ubuntu-latest
     strategy:
       matrix:
         node-version:
+          - 16
+          - 14
+          - 12
           - 10
           - 8
           - 6

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -13,6 +13,7 @@ jobs:
     strategy:
       matrix:
         node-version:
+          - 22
           - 20
           - 18
     steps:

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -22,9 +22,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm install
       - run: npm run build
-      - run: node tests/test.js
-      - run: node tests/esm.mjs
-      - run: node tests/types.mjs
+      - run: npm test
   legacy:
     name: Node v${{ matrix.node-version }} (Legacy)
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+picocolors.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 picocolors.mjs
+tests/types.mjs

--- a/build-esm.mjs
+++ b/build-esm.mjs
@@ -1,0 +1,28 @@
+import { readFile, writeFile } from "node:fs/promises"
+
+let script = await readFile("picocolors.js", "utf8")
+
+script = script.replace('require != null && require("tty")', '(await import("tty"))')
+
+let lines = script.split(/\r?\n/)
+lines.splice(-3, 3)
+script = lines.join("\n")
+
+script += `
+let colors = createColors()
+colors.createColors = createColors
+let {
+  reset, bold, dim, italic, underline, inverse, hidden, strikethrough, 
+  black, red, green, yellow, blue, magenta, cyan, white, gray,
+  bgBlack, bgRed, bgGreen, bgYellow, bgBlue, bgMagenta, bgCyan, bgWhite
+} = colors
+
+export {
+  isColorSupported, reset, bold, dim, italic, underline, inverse, hidden, strikethrough, 
+  black, red, green, yellow, blue, magenta, cyan, white, gray,
+  bgBlack, bgRed, bgGreen, bgYellow, bgBlue, bgMagenta, bgCyan, bgWhite, createColors
+}
+export default colors
+`;
+
+await writeFile("picocolors.mjs", script)

--- a/package.json
+++ b/package.json
@@ -17,8 +17,9 @@
   "sideEffects": false,
   "description": "The tiniest and the fastest library for terminal output formatting with ANSI colors",
   "scripts": {
-    "build": "node build-esm.mjs && tsc --module esnext tests/types.mts",
-    "test": "node tests/test.js"
+    "build": "node build-esm.mjs",
+    "pretest": "tsc --module esnext tests/types.mts",
+    "test": "node tests/test.js && node tests/esm.mjs && node tests/types.mjs"
   },
   "files": [
     "picocolors.*",

--- a/package.json
+++ b/package.json
@@ -2,13 +2,22 @@
   "name": "picocolors",
   "version": "1.1.1",
   "main": "./picocolors.js",
+  "module": "./picocolors.mjs",
   "types": "./picocolors.d.ts",
   "browser": {
     "./picocolors.js": "./picocolors.browser.js"
   },
+  "exports": {
+    ".": {
+      "types": "./picocolors.d.ts",
+      "require": "./picocolors.js",
+      "import": "./picocolors.mjs"
+    }
+  },
   "sideEffects": false,
   "description": "The tiniest and the fastest library for terminal output formatting with ANSI colors",
   "scripts": {
+    "build": "node build-esm.mjs",
     "test": "node tests/test.js"
   },
   "files": [
@@ -26,15 +35,15 @@
   "repository": "alexeyraspopov/picocolors",
   "license": "ISC",
   "devDependencies": {
-    "ansi-colors": "^4.1.1",
+    "ansi-colors": "^4.1.3",
     "chalk": "^4.1.2",
-    "clean-publish": "^3.0.3",
-    "cli-color": "^2.0.0",
-    "colorette": "^2.0.12",
-    "kleur": "^4.1.4",
-    "mitata": "^1.0.10",
-    "nanocolors": "^0.2.12",
-    "prettier": "^3.3.3",
+    "clean-publish": "^3.4.5",
+    "cli-color": "^2.0.4",
+    "colorette": "^2.0.20",
+    "kleur": "^4.1.5",
+    "mitata": "^1.0.32",
+    "nanocolors": "^0.2.13",
+    "prettier": "^2.8.8",
     "yoctocolors": "^2.1.1"
   },
   "prettier": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "sideEffects": false,
   "description": "The tiniest and the fastest library for terminal output formatting with ANSI colors",
   "scripts": {
-    "build": "node build-esm.mjs",
+    "build": "node build-esm.mjs && tsc --module esnext tests/types.mts",
     "test": "node tests/test.js"
   },
   "files": [
@@ -44,6 +44,7 @@
     "mitata": "^1.0.32",
     "nanocolors": "^0.2.13",
     "prettier": "^2.8.8",
+    "typescript": "^5.7.3",
     "yoctocolors": "^2.1.1"
   },
   "prettier": {

--- a/picocolors.d.ts
+++ b/picocolors.d.ts
@@ -1,5 +1,38 @@
-import { Colors } from "./types"
+import { Colors, Formatter } from "./types"
 
-declare const picocolors: Colors & { createColors: (enabled?: boolean) => Colors }
+export { Colors }
 
-export = picocolors
+declare type Generator = (enabled?: boolean) => Colors
+
+declare const picocolors: Colors & { createColors: Generator }
+
+export default picocolors
+
+export let isColorSupported: boolean
+export let reset: Formatter
+export let bold: Formatter
+export let dim: Formatter
+export let italic: Formatter
+export let underline: Formatter
+export let inverse: Formatter
+export let hidden: Formatter
+export let strikethrough: Formatter
+export let black: Formatter
+export let red: Formatter
+export let green: Formatter
+export let yellow: Formatter
+export let blue: Formatter
+export let magenta: Formatter
+export let cyan: Formatter
+export let white: Formatter
+export let gray: Formatter
+export let bgBlack: Formatter
+export let bgRed: Formatter
+export let bgGreen: Formatter
+export let bgYellow: Formatter
+export let bgBlue: Formatter
+export let bgMagenta: Formatter
+export let bgCyan: Formatter
+export let bgWhite: Formatter
+
+export let createColors: Generator

--- a/tests/esm.mjs
+++ b/tests/esm.mjs
@@ -1,0 +1,27 @@
+import pc from "../picocolors.mjs"
+import { bold, createColors } from "../picocolors.mjs"
+import assert from "node:assert"
+
+test("import all", () => {
+	assert.equal(typeof pc, "object")
+	assert.equal(typeof pc.bold, "function")
+	assert.equal(typeof pc.createColors, "function")
+})
+
+test("import bold", () => {
+	assert.equal(typeof bold, "function")
+})
+
+test("import createColors", () => {
+	assert.equal(typeof createColors, "function")
+})
+
+function test(name, fn) {
+	try {
+		fn()
+		console.log(pc.green("✓ " + name))
+	} catch (error) {
+		console.log(pc.red("✗ " + name))
+		throw error
+	}
+}

--- a/tests/types.mts
+++ b/tests/types.mts
@@ -1,0 +1,25 @@
+import pc from "../picocolors.mjs"
+import { bold, createColors, Colors } from "../picocolors.mjs"
+
+test("default export", () => {
+  let _result: string = pc.bold("test")
+})
+
+test("named exports", () => {
+  let _result: string = bold("test")
+})
+
+test("factory function", () => {
+  let _result1: Colors = pc.createColors()
+  let _result2: Colors = createColors()
+})
+
+function test(name: string, fn: () => void) : void {
+	try {
+		fn()
+		console.log(pc.green("✓ " + name))
+	} catch (error) {
+		console.log(pc.red("✗ " + name))
+		throw error
+	}
+}


### PR DESCRIPTION
## Proposal

Allow importing single exported named functions:

    import { bold, green } from "picocolors"

## Problem

If named exports are used today, the following error will be thrown:

```
> rollup -c --environment NODE_ENV:production

[!] SyntaxError: Named export 'bold' not found. The requested module 'picocolors' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from 'picocolors';
const { bold, green } = pkg;

file:///Users/prantlf/Sources/github/d3/rollup.config.js:2
import { bold, green } from 'picocolors';
         ^^^^
    at ModuleJob._instantiate (node:internal/modules/esm/module_job:132:21)
```

## Changes

Expose an ESM module with named exports: `picocolors.mjs`. Generate its content from `picololors.js` by `build.mjs`. Test that the exports can be imported by `test/esm.mjs`.

Also upgrade development dependencies. Keep the same major versions of `chalk` and `clean-publish` not to break the legacy Node.js tests.

Also include tests with Node.js 20 and move versions older than 18 to the legacy group. Upgrade GitHub actions for modern Node.js.

Also fixes #50.
Also fixes #59.
