### PR TITLE
Add bechmarks for chalk 5 and yoctocolors

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -19,6 +19,8 @@ jobs:
         with:
           node-version: 18
       - run: npm install
+      - run: npm run build
+      - run: npm run build-benchmarks
       - name: Ensure color support detection
         run: node tests/environments.js
       - name: Simple API calls

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -32,7 +32,6 @@ jobs:
         node-version:
           - 10
           - 8
-          - 6
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+benchmarks/chalk5.js
+benchmarks/yoctocolors.js
 node_modules

--- a/README.md
+++ b/README.md
@@ -38,13 +38,14 @@ The space in node_modules including sub-dependencies:
 
 ```diff
 $ node ./benchmarks/size.js
-Data from packagephobia.com
-  chalk       101 kB
-  cli-color  1249 kB
-  ansi-colors  25 kB
-  kleur        21 kB
+  chalk@5.3.0  43 kB
+  chalk@4.1.2 101 kB
+  cli-color   796 kB
+  ansi-colors  27 kB
+  kleur        20 kB
   colorette    17 kB
-  nanocolors   16 kB
+  nanocolors   15 kB
+  yoctocolors   7 kB
 + picocolors    7 kB
 ```
 
@@ -52,42 +53,48 @@ Library loading time:
 
 ```diff
 $ node ./benchmarks/loading.js
-  chalk          6.167 ms
-  cli-color     31.431 ms
-  ansi-colors    1.585 ms
-  kleur          2.008 ms
-  kleur/colors   0.773 ms
-  colorette      2.476 ms
-  nanocolors     0.833 ms
-+ picocolors     0.466 ms
+  chalk5         7.713 ms
+  chalk4         5.372 ms
+  cli-color     32.428 ms
+  ansi-colors    1.420 ms
+  kleur          2.345 ms
+  kleur/colors   0.960 ms
+  colorette      0.887 ms
+  nanocolors     0.708 ms
+  yoctocolors    0.679 ms
++ picocolors     0.388 ms
 ```
 
 Benchmark for simple use case:
 
 ```diff
 $ node ./benchmarks/simple.js
-  chalk         24,066,342 ops/sec
-  cli-color        938,700 ops/sec
-  ansi-colors    4,532,542 ops/sec
-  kleur         20,343,122 ops/sec
-  kleur/colors  35,415,770 ops/sec
-  colorette     34,244,834 ops/sec
-  nanocolors    33,443,265 ops/sec
-+ picocolors    33,271,645 ops/sec
+  chalk5         26,287,893 ops/sec
+  chalk4         25,221,564 ops/sec
+  cli-color       1,412,525 ops/sec
+  ansi-colors     6,463,786 ops/sec
+  kleur          26,363,857 ops/sec
+  kleur/colors   52,166,754 ops/sec
+  colorette      50,574,214 ops/sec
+  nanocolors     51,646,373 ops/sec
+  yoctocolors   195,458,649 ops/sec
++ picocolors     50,840,902 ops/sec
 ```
 
 Benchmark for complex use cases:
 
 ```diff
 $ node ./benchmarks/complex.js
-  chalk            969,915 ops/sec
-  cli-color        131,639 ops/sec
-  ansi-colors      342,250 ops/sec
-  kleur            611,880 ops/sec
-  kleur/colors   1,129,526 ops/sec
-  colorette      1,747,277 ops/sec
-  nanocolors     1,251,312 ops/sec
-+ picocolors     2,024,086 ops/sec
+  chalk5          1,178,597 ops/sec
+  chalk4          1,215,094 ops/sec
+  cli-color         152,419 ops/sec
+  ansi-colors       558,016 ops/sec
+  kleur           1,251,816 ops/sec
+  kleur/colors    1,523,289 ops/sec
+  colorette       1,813,436 ops/sec
+  nanocolors      1,682,924 ops/sec
+  yoctocolors     4,424,045 ops/sec
++ picocolors      2,747,818 ops/sec
 ```
 
 ## Usage

--- a/benchmarks/complex.js
+++ b/benchmarks/complex.js
@@ -9,16 +9,18 @@ let benchmark = require("benchmark")
 let colorette = require("colorette")
 let kleur = require("kleur")
 let kleurColors = require("kleur/colors")
-let chalk = require("chalk")
+let chalk5 = require("./chalk5").default
+let chalk4 = require("chalk4")
 let ansi = require("ansi-colors")
 let cliColor = require("cli-color")
 let picocolors = require("../picocolors.js")
 let nanocolors = require("nanocolors")
+let yoctocolors = require("./yoctocolors")
 
 function formatNumber(number) {
 	return String(number)
 		.replace(/\d{3}$/, ",$&")
-		.replace(/^(\d|\d\d)(\d{3},)/, "$1,$2")
+		.replace(/^(\d{1,3})(\d{3},)/, "$1,$2")
 }
 
 let suite = new benchmark.Suite()
@@ -27,14 +29,24 @@ let out
 let index = 1e8
 
 suite
-	.add("chalk", () => {
+	.add("chalk5", () => {
 		out =
-			chalk.red(".") +
-			chalk.yellow(".") +
-			chalk.green(".") +
-			chalk.bgRed(chalk.black(" ERROR ")) +
-			chalk.red(
-				" Add plugin " + chalk.yellow("name") + " to use time limit with " + chalk.yellow(++index)
+			chalk5.red(".") +
+			chalk5.yellow(".") +
+			chalk5.green(".") +
+			chalk5.bgRed(chalk5.black(" ERROR ")) +
+			chalk5.red(
+				" Add plugin " + chalk5.yellow("name") + " to use time limit with " + chalk5.yellow(++index)
+			)
+	})
+	.add("chalk4", () => {
+		out =
+			chalk4.red(".") +
+			chalk4.yellow(".") +
+			chalk4.green(".") +
+			chalk4.bgRed(chalk4.black(" ERROR ")) +
+			chalk4.red(
+				" Add plugin " + chalk4.yellow("name") + " to use time limit with " + chalk4.yellow(++index)
 			)
 	})
 	.add("cli-color", () => {
@@ -109,6 +121,19 @@ suite
 					nanocolors.yellow(++index)
 			)
 	})
+	.add("yoctocolors", () => {
+		out =
+			yoctocolors.red(".") +
+			yoctocolors.yellow(".") +
+			yoctocolors.green(".") +
+			yoctocolors.bgRed(yoctocolors.black(" ERROR ")) +
+			yoctocolors.red(
+				" Add plugin " +
+					yoctocolors.yellow("name") +
+					" to use time limit with " +
+					yoctocolors.yellow(++index)
+			)
+	})
 	.add("picocolors", () => {
 		out =
 			picocolors.red(".") +
@@ -125,7 +150,7 @@ suite
 	.on("cycle", event => {
 		let prefix = event.target.name === "picocolors" ? "+ " : "  "
 		let name = event.target.name.padEnd("kleur/colors  ".length)
-		let hz = formatNumber(event.target.hz.toFixed(0)).padStart(10)
+		let hz = formatNumber(event.target.hz.toFixed(0)).padStart(11)
 		process.stdout.write(`${prefix}${name}${picocolors.bold(hz)} ops/sec\n`)
 	})
 	.on("error", event => {

--- a/benchmarks/complex.mjs
+++ b/benchmarks/complex.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+
+// Benchmark results are unstable. To have more stable results:
+// 1. Restart OS. Do not run any applications. Put power cable to laptop.
+// 2. Run tests 5 times.
+// 3. Took the best result for each candidate.
+
+import benchmark from "benchmark"
+import * as colorette from "colorette"
+import kleur from "kleur"
+import * as kleurColors from "kleur/colors"
+import chalk5 from "chalk5"
+import chalk4 from "chalk4"
+import ansi from "ansi-colors"
+import cliColor from "cli-color"
+import picocolors from "../picocolors.js"
+import * as nanocolors from "nanocolors"
+import * as yoctocolors from "yoctocolors"
+
+function formatNumber(number) {
+	return String(number)
+		.replace(/\d{3}$/, ",$&")
+		.replace(/^(\d{1,3})(\d{3},)/, "$1,$2")
+}
+
+let suite = new benchmark.Suite()
+let out
+
+let index = 1e8
+
+suite
+	.add("chalk5", () => {
+		out =
+			chalk5.red(".") +
+			chalk5.yellow(".") +
+			chalk5.green(".") +
+			chalk5.bgRed(chalk5.black(" ERROR ")) +
+			chalk5.red(
+				" Add plugin " + chalk5.yellow("name") + " to use time limit with " + chalk5.yellow(++index)
+			)
+	})
+	.add("chalk4", () => {
+		out =
+			chalk4.red(".") +
+			chalk4.yellow(".") +
+			chalk4.green(".") +
+			chalk4.bgRed(chalk4.black(" ERROR ")) +
+			chalk4.red(
+				" Add plugin " + chalk4.yellow("name") + " to use time limit with " + chalk4.yellow(++index)
+			)
+	})
+	.add("cli-color", () => {
+		out =
+			cliColor.red(".") +
+			cliColor.yellow(".") +
+			cliColor.green(".") +
+			cliColor.bgRed(cliColor.black(" ERROR ")) +
+			cliColor.red(
+				" Add plugin " +
+					cliColor.yellow("name") +
+					" to use time limit with " +
+					cliColor.yellow(++index)
+			)
+	})
+	.add("ansi-colors", () => {
+		out =
+			ansi.red(".") +
+			ansi.yellow(".") +
+			ansi.green(".") +
+			ansi.bgRed(ansi.black(" ERROR ")) +
+			ansi.red(
+				" Add plugin " + ansi.yellow("name") + " to use time limit with " + ansi.yellow(++index)
+			)
+	})
+	.add("kleur", () => {
+		out =
+			kleur.red(".") +
+			kleur.yellow(".") +
+			kleur.green(".") +
+			kleur.bgRed(kleur.black(" ERROR ")) +
+			kleur.red(
+				" Add plugin " + kleur.yellow("name") + " to use time limit with " + kleur.yellow(++index)
+			)
+	})
+	.add("kleur/colors", () => {
+		out =
+			kleurColors.red(".") +
+			kleurColors.yellow(".") +
+			kleurColors.green(".") +
+			kleurColors.bgRed(kleurColors.black(" ERROR ")) +
+			kleurColors.red(
+				" Add plugin " +
+					kleurColors.yellow("name") +
+					" to use time limit with " +
+					kleurColors.yellow(++index)
+			)
+	})
+	.add("colorette", () => {
+		out =
+			colorette.red(".") +
+			colorette.yellow(".") +
+			colorette.green(".") +
+			colorette.bgRed(colorette.black(" ERROR ")) +
+			colorette.red(
+				" Add plugin " +
+					colorette.yellow("name") +
+					" to use time limit with " +
+					colorette.yellow(++index)
+			)
+	})
+	.add("nanocolors", () => {
+		out =
+			nanocolors.red(".") +
+			nanocolors.yellow(".") +
+			nanocolors.green(".") +
+			nanocolors.bgRed(nanocolors.black(" ERROR ")) +
+			nanocolors.red(
+				" Add plugin " +
+					nanocolors.yellow("name") +
+					" to use time limit with " +
+					nanocolors.yellow(++index)
+			)
+	})
+	.add("yoctocolors", () => {
+		out =
+			yoctocolors.red(".") +
+			yoctocolors.yellow(".") +
+			yoctocolors.green(".") +
+			yoctocolors.bgRed(yoctocolors.black(" ERROR ")) +
+			yoctocolors.red(
+				" Add plugin " +
+					yoctocolors.yellow("name") +
+					" to use time limit with " +
+					yoctocolors.yellow(++index)
+			)
+	})
+	.add("picocolors", () => {
+		out =
+			picocolors.red(".") +
+			picocolors.yellow(".") +
+			picocolors.green(".") +
+			picocolors.bgRed(picocolors.black(" ERROR ")) +
+			picocolors.red(
+				" Add plugin " +
+					picocolors.yellow("name") +
+					" to use time limit with " +
+					picocolors.yellow(`${++index}`)
+			)
+	})
+	.on("cycle", event => {
+		let prefix = event.target.name === "picocolors" ? "+ " : "  "
+		let name = event.target.name.padEnd("kleur/colors  ".length)
+		let hz = formatNumber(event.target.hz.toFixed(0)).padStart(11)
+		process.stdout.write(`${prefix}${name}${picocolors.bold(hz)} ops/sec\n`)
+	})
+	.on("error", event => {
+		process.stderr.write(picocolors.red(event.target.error.toString()) + "\n")
+		process.exit(1)
+	})
+	.run()

--- a/benchmarks/loading-runner.js
+++ b/benchmarks/loading-runner.js
@@ -7,8 +7,12 @@ function showTime(name) {
 }
 
 before = performance.now()
-let chalk = require("chalk")
-showTime("chalk")
+let chalk5 = require("./chalk5")
+showTime("chalk5")
+
+before = performance.now()
+let chalk4 = require("chalk4")
+showTime("chalk4")
 
 before = performance.now()
 let cliColor = require("cli-color")
@@ -33,6 +37,10 @@ showTime("colorette")
 before = performance.now()
 let nanocolors = require("nanocolors")
 showTime("nanocolors")
+
+before = performance.now()
+let yoctocolors = require("./yoctocolors")
+showTime("yoctocolors")
 
 before = performance.now()
 let picocolors = require("../picocolors.js")

--- a/benchmarks/loading-runner.mjs
+++ b/benchmarks/loading-runner.mjs
@@ -1,0 +1,47 @@
+import { performance } from "perf_hooks"
+
+let before
+function showTime(name) {
+	let after = performance.now()
+	process.stdout.write(name + " " + (after - before) + "\n")
+}
+
+before = performance.now()
+let chalk5 = await import("./chalk5.js")
+showTime("chalk5")
+
+before = performance.now()
+let chalk4 = await import("chalk4")
+showTime("chalk4")
+
+before = performance.now()
+let cliColor = await import("cli-color")
+showTime("cli-color")
+
+before = performance.now()
+let ansi = await import("ansi-colors")
+showTime("ansi-colors")
+
+before = performance.now()
+let kleur = await import("kleur")
+showTime("kleur")
+
+before = performance.now()
+let kleurColors = await import("kleur/colors")
+showTime("kleur/colors")
+
+before = performance.now()
+let colorette = await import("colorette")
+showTime("colorette")
+
+before = performance.now()
+let nanocolors = await import("nanocolors")
+showTime("nanocolors")
+
+before = performance.now()
+let yoctocolors = await import("./yoctocolors.js")
+showTime("yoctocolors")
+
+before = performance.now()
+let picocolors = await import("../picocolors.js")
+showTime("picocolors")

--- a/benchmarks/loading.js
+++ b/benchmarks/loading.js
@@ -4,10 +4,12 @@ let { execSync } = require("child_process")
 
 let RUNS = 50
 
+let esm = process.argv[2] === "--esm"
+let ext = esm ? "mjs" : "js"
 let results = {}
 
 for (let i = 0; i < RUNS; i++) {
-	let output = execSync("node ./benchmarks/loading-runner.js").toString()
+	let output = execSync(`node ./benchmarks/loading-runner.${ext}`).toString()
 	output
 		.trim()
 		.split("\n")
@@ -17,6 +19,7 @@ for (let i = 0; i < RUNS; i++) {
 		})
 }
 
+console.log(`Results for ${esm ? 'ESM' : 'CJS'}:`)
 for (let name in results) {
 	let prefix = name === "picocolors" ? "+ " : "  "
 	let title = name.padEnd("kleur/colors  ".length)

--- a/benchmarks/simple.js
+++ b/benchmarks/simple.js
@@ -9,32 +9,39 @@ let benchmark = require("benchmark")
 let colorette = require("colorette")
 let kleur = require("kleur")
 let kleurColors = require("kleur/colors")
-let chalk = require("chalk")
+let chalk5 = require("./chalk5").default
+let chalk4 = require("chalk4")
 let ansi = require("ansi-colors")
 let cliColor = require("cli-color")
 let picocolors = require("../picocolors.js")
 let nanocolors = require("nanocolors")
+let yoctocolors = require("./yoctocolors")
 
 function formatNumber(number) {
 	return String(number)
 		.replace(/\d{3}$/, ",$&")
-		.replace(/^(\d|\d\d)(\d{3},)/, "$1,$2")
+		.replace(/^(\d{1,3})(\d{3},)/, "$1,$2")
 }
 
 console.log(colorette.green("colorette"))
 console.log(kleur.green("kleur"))
-console.log(chalk.green("chalk"))
+console.log(chalk5.green("chalk5"))
+console.log(chalk4.green("chalk4"))
 console.log(ansi.green("ansi"))
 console.log(cliColor.green("cliColor"))
 console.log(picocolors.green("picocolors"))
 console.log(nanocolors.green("nanocolors"))
+console.log(yoctocolors.green("yoctocolors"))
 
 let suite = new benchmark.Suite()
 let out
 
 suite
-	.add("chalk", () => {
-		out = chalk.red("Add plugin to use time limit")
+	.add("chalk5", () => {
+		out = chalk5.red("Add plugin to use time limit")
+	})
+	.add("chalk4", () => {
+		out = chalk4.red("Add plugin to use time limit")
 	})
 	.add("cli-color", () => {
 		out = cliColor.red("Add plugin to use time limit")
@@ -54,13 +61,16 @@ suite
 	.add("nanocolors", () => {
 		out = nanocolors.red("Add plugin to use time limit")
 	})
+	.add("yoctocolors", () => {
+		out = yoctocolors.red("Add plugin to use time limit")
+	})
 	.add("picocolors", () => {
 		out = picocolors.red("Add plugin to use time limit")
 	})
 	.on("cycle", event => {
 		let prefix = event.target.name === "picocolors" ? "+ " : "  "
 		let name = event.target.name.padEnd("kleur/colors  ".length)
-		let hz = formatNumber(event.target.hz.toFixed(0)).padStart(10)
+		let hz = formatNumber(event.target.hz.toFixed(0)).padStart(11)
 		process.stdout.write(`${prefix}${name}${picocolors.bold(hz)} ops/sec\n`)
 	})
 	.on("error", event => {

--- a/benchmarks/simple.mjs
+++ b/benchmarks/simple.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+
+// Benchmark results are unstable. To have more stable results:
+// 1. Restart OS. Do not run any applications. Put power cable to laptop.
+// 2. Run tests 5 times.
+// 3. Took the best result for each candidate.
+
+import benchmark from "benchmark"
+import * as colorette from "colorette"
+import kleur from "kleur"
+import * as kleurColors from "kleur/colors"
+import chalk5 from "chalk5"
+import chalk4 from "chalk4"
+import ansi from "ansi-colors"
+import cliColor from "cli-color"
+import picocolors from "../picocolors.js"
+import * as nanocolors from "nanocolors"
+import * as yoctocolors from "yoctocolors"
+
+function formatNumber(number) {
+	return String(number)
+		.replace(/\d{3}$/, ",$&")
+		.replace(/^(\d{1,3})(\d{3},)/, "$1,$2")
+}
+
+console.log(colorette.green("colorette"))
+console.log(kleur.green("kleur"))
+console.log(chalk5.green("chalk5"))
+console.log(chalk4.green("chalk4"))
+console.log(ansi.green("ansi"))
+console.log(cliColor.green("cliColor"))
+console.log(picocolors.green("picocolors"))
+console.log(nanocolors.green("nanocolors"))
+console.log(yoctocolors.green("yoctocolors"))
+
+let suite = new benchmark.Suite()
+let out
+
+suite
+	.add("chalk5", () => {
+		out = chalk5.red("Add plugin to use time limit")
+	})
+	.add("chalk4", () => {
+		out = chalk4.red("Add plugin to use time limit")
+	})
+	.add("cli-color", () => {
+		out = cliColor.red("Add plugin to use time limit")
+	})
+	.add("ansi-colors", () => {
+		out = ansi.red("Add plugin to use time limit")
+	})
+	.add("kleur", () => {
+		out = kleur.red("Add plugin to use time limit")
+	})
+	.add("kleur/colors", () => {
+		out = kleurColors.red("Add plugin to use time limit")
+	})
+	.add("colorette", () => {
+		out = colorette.red("Add plugin to use time limit")
+	})
+	.add("nanocolors", () => {
+		out = nanocolors.red("Add plugin to use time limit")
+	})
+	.add("yoctocolors", () => {
+		out = yoctocolors.red("Add plugin to use time limit")
+	})
+	.add("picocolors", () => {
+		out = picocolors.red("Add plugin to use time limit")
+	})
+	.on("cycle", event => {
+		let prefix = event.target.name === "picocolors" ? "+ " : "  "
+		let name = event.target.name.padEnd("kleur/colors  ".length)
+		let hz = formatNumber(event.target.hz.toFixed(0)).padStart(11)
+		process.stdout.write(`${prefix}${name}${picocolors.bold(hz)} ops/sec\n`)
+	})
+	.on("error", event => {
+		process.stderr.write(picocolors.red(event.target.error.toString()) + "\n")
+		process.exit(1)
+	})
+	.run()

--- a/benchmarks/size.js
+++ b/benchmarks/size.js
@@ -40,6 +40,7 @@ async function start() {
 	await benchmark("  kleur")
 	await benchmark("  colorette")
 	await benchmark("  nanocolors")
+	await benchmark("  yoctocolors")
 	await benchmark("+ picocolors")
 }
 

--- a/benchmarks/size.js
+++ b/benchmarks/size.js
@@ -34,7 +34,8 @@ async function benchmark(lib) {
 
 async function start() {
 	process.stdout.write(gray("Data from packagephobia.com\n"))
-	await benchmark("  chalk")
+	await benchmark("  chalk@5.3.0")
+	await benchmark("  chalk@4.1.2")
 	await benchmark("  cli-color")
 	await benchmark("  ansi-colors")
 	await benchmark("  kleur")

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "sideEffects": false,
   "description": "The tiniest and the fastest library for terminal output formatting with ANSI colors",
   "scripts": {
+    "build-benchmarks": "node print-chalk5.mjs | esbuild --outfile=benchmarks/chalk5.js --bundle --platform=node && node print-yoctocolors.mjs | esbuild --outfile=benchmarks/yoctocolors.js --bundle --platform=node",
     "test": "node tests/test.js"
   },
   "files": [
@@ -26,15 +27,18 @@
   "repository": "alexeyraspopov/picocolors",
   "license": "ISC",
   "devDependencies": {
-    "ansi-colors": "^4.1.1",
+    "ansi-colors": "^4.1.3",
     "benchmark": "^2.1.4",
-    "chalk": "^4.1.2",
-    "clean-publish": "^3.0.3",
-    "cli-color": "^2.0.0",
-    "colorette": "^2.0.12",
-    "kleur": "^4.1.4",
-    "nanocolors": "^0.2.12",
-    "prettier": "^2.4.1"
+    "chalk4": "npm:chalk@^4.1.2",
+    "chalk5": "npm:chalk@^5.3.0",
+    "clean-publish": "^3.4.5",
+    "cli-color": "^2.0.3",
+    "colorette": "^2.0.20",
+    "esbuild": "^0.20.1",
+    "kleur": "^4.1.5",
+    "nanocolors": "^0.2.13",
+    "prettier": "^2.8.8",
+    "yoctocolors": "^1.0.0"
   },
   "prettier": {
     "printWidth": 100,

--- a/print-chalk5.mjs
+++ b/print-chalk5.mjs
@@ -1,0 +1,10 @@
+import { readFile } from "node:fs/promises"
+
+let script = await readFile("node_modules/chalk5/source/index.js", "utf8")
+
+script = script.replace("./utilities.js", "./node_modules/chalk5/source/utilities.js")
+script = script.replace("./vendor/ansi-styles/index.js", "./node_modules/chalk5/source/vendor/ansi-styles/index.js")
+script = script.replace("#ansi-styles", "./node_modules/chalk5/source/vendor/ansi-styles/index.js")
+script = script.replace("#supports-color", "./node_modules/chalk5/source/vendor/supports-color/index.js")
+
+process.stdout.write(script);

--- a/print-yoctocolors.mjs
+++ b/print-yoctocolors.mjs
@@ -1,0 +1,7 @@
+import { readFile } from "node:fs/promises"
+
+let script = await readFile("node_modules/yoctocolors/index.js", "utf8")
+
+script = script.replace("import tty from 'node:tty'", "const tty = require('node:tty')")
+
+process.stdout.write(script);

--- a/print-yoctocolors.mjs
+++ b/print-yoctocolors.mjs
@@ -4,4 +4,17 @@ let script = await readFile("node_modules/yoctocolors/index.js", "utf8")
 
 script = script.replace("import tty from 'node:tty'", "const tty = require('node:tty')")
 
+// let lines = script.split(/\r?\n/)
+// lines.splice(0, 4)
+
+// lines.unshift(
+// `const argv = process.argv || [], env = process.env, hasColors =
+// !("NO_COLOR" in env || argv.includes("--no-color")) &&
+// ("FORCE_COLOR" in env ||
+//   argv.includes("--color") ||
+//   process.platform === "win32" ||
+//   (require != null && require("tty").isatty(1) && env.TERM !== "dumb") ||
+//   "CI" in env);`)
+// script = lines.join("\n")
+
 process.stdout.write(script);


### PR DESCRIPTION
Fixes #45.

## Changes

The latest version of `chalk` does not support CJS, but it is possible to bundle it in the CJS format. It is worth testing the latest available version.

`yoctocolors` does not support CJS, but it is possible to bundle it in the CJS format. This library aspires to be the new tiniest one. It supports `FORCE_COLOR` and `NO_COLOR` too. It is worth comparing it to `picocolors`.

Split `chalk` to `chalk4` and `chalk5` using NPM module aliases. Also upgrade development dependencies. Keep the same major version of `clean-publish` not to break the legacy Node.js tests.

Use `esbuild` to create CJS bundles of `chalk5` and `yoctocolors`. Add `chalk5` and `yoctocolors` to every benchmark. Rename the former `chalk` tests to `chalk4`.

## Results

The `simple.js` benchmark shows 5% decrease of performance in `chalk` 5 against `chalk` 4. `yoctocolors` beat `picocolors` by 284%.

```
❯ node benchmarks/simple.js
colorette
kleur
chalk5
chalk4
ansi
cliColor
picocolors
nanocolors
yoctocolors
  chalk5         26,287,893 ops/sec
  chalk4         25,221,564 ops/sec
  cli-color       1,412,525 ops/sec
  ansi-colors     6,463,786 ops/sec
  kleur          26,363,857 ops/sec
  kleur/colors   52,166,754 ops/sec
  colorette      50,574,214 ops/sec
  nanocolors     51,646,373 ops/sec
  yoctocolors   195,458,649 ops/sec
+ picocolors     50,840,902 ops/sec
```

The `complex.js` benchmark shows 3% decrease of performance in `chalk` 5 against `chalk` 4. `yoctocolors` beat `picocolors` by 61%.

```
❯ node benchmarks/complex.js
  chalk5          1,178,597 ops/sec
  chalk4          1,215,094 ops/sec
  cli-color         152,419 ops/sec
  ansi-colors       558,016 ops/sec
  kleur           1,251,816 ops/sec
  kleur/colors    1,523,289 ops/sec
  colorette       1,813,436 ops/sec
  nanocolors      1,682,924 ops/sec
  yoctocolors     4,424,045 ops/sec
+ picocolors      2,747,818 ops/sec
```

The `loading.js` benchmark shows 44% decrease of performance in `chalk` 5 against `chalk` 4. `yoctocolors` is 75% slower than `picocolors`. I tried replacing the color detection in `yoctocolors` with the code from `picocolors` and the loading time went down to 0.588 ms, 52% slower than `picocolors`.


```
❯ node benchmarks/loading.js
  chalk5         7.713 ms
  chalk4         5.372 ms
  cli-color     32.428 ms
  ansi-colors    1.420 ms
  kleur          2.345 ms
  kleur/colors   0.960 ms
  colorette      0.887 ms
  nanocolors     0.708 ms
  yoctocolors    0.679 ms
+ picocolors     0.388 ms
```

The `size.js` benchmark shows 57% size reduction for `chalk` 5 against `chalk` 4. `yoctocolors` is practically the same as `picocolors`. This benchmark isn't reliable, because the size of the actually used code may be much smaller, as the comparison of the single-file libraries `yoctocolors` and `picocolors` shows.

```
❯ node benchmarks/size.js
Data from packagephobia.com
  chalk@5.3.0  43 kB
  chalk@4.1.2 101 kB
  cli-color   796 kB
  ansi-colors  27 kB
  kleur        20 kB
  colorette    17 kB
  nanocolors   15 kB
  yoctocolors   7 kB
+ picocolors    7 kB

❯ minified-size picocolors.js
picocolors.js: 2.6 kB, 1.86 kB, 626 B, 528 B

❯ minified-size benchmarks/yoctocolors.js
benchmarks/yoctocolors.js: 2.92 kB, 1.82 kB, 789 B, 697 B```
```
