### PR TITLE
feat: inline replacement code

### DIFF
--- a/picocolors.js
+++ b/picocolors.js
@@ -13,20 +13,18 @@ let formatter =
 	input => {
 		let string = "" + input
 		let index = string.indexOf(close, open.length)
-		return ~index
-			? open + replaceClose(string, close, replace, index) + close
-			: open + string + close
-	}
-
-let replaceClose = (string, close, replace, index) => {
-	let result = ""
-	let cursor = 0
-	do {
-		result += string.substring(cursor, index) + replace
-		cursor = index + close.length
-		index = string.indexOf(close, cursor)
-	} while (~index)
-	return result + string.substring(cursor)
+		if (index === -1) {
+			return open + string + close
+		}
+		let result = ""
+		let cursor = 0
+		let closeLength = close.length
+		do {
+			result += string.substring(cursor, index) + replace
+			cursor = index + closeLength
+			index = string.indexOf(close, cursor)
+		} while (~index)
+		return open + result + string.substring(cursor) + close
 }
 
 let createColors = (enabled = isColorSupported) => {


### PR DESCRIPTION
Removing the extra function call seems to improve performance slightly.

This gives you your throne back as fastest colors library around

simple benchmark:

```
┌─────────┬────────────────┬──────────────┬────────────────────┬──────────┬─────────┐
│ (index) │ Task Name      │ ops/sec      │ Average Time (ns)  │ Margin   │ Samples │
├─────────┼────────────────┼──────────────┼────────────────────┼──────────┼─────────┤
│ 0       │ 'chalk'        │ '9,170,752'  │ 109.04230818989915 │ '±0.19%' │ 4585377 │
│ 1       │ 'cli-color'    │ '1,198,844'  │ 834.1363661388364  │ '±0.57%' │ 599423  │
│ 2       │ 'ansi-colors'  │ '4,218,888'  │ 237.0292745247684  │ '±0.75%' │ 2109445 │
│ 3       │ 'kleur'        │ '9,145,583'  │ 109.34239366227348 │ '±0.26%' │ 4572792 │
│ 4       │ 'kleur/colors' │ '9,881,558'  │ 101.19860953145326 │ '±0.10%' │ 4940780 │
│ 5       │ 'colorette'    │ '10,239,583' │ 97.6602248683991   │ '±0.11%' │ 5119792 │
│ 6       │ 'nanocolors'   │ '10,178,907' │ 98.24237177530287  │ '±0.12%' │ 5089454 │
│ 7       │ 'yoctccolors'  │ '10,286,422' │ 97.21553282289035  │ '±0.08%' │ 5143212 │
│ 8       │ 'picocolors'   │ '10,321,455' │ 96.8855599440762   │ '±0.08%' │ 5160728 │
└─────────┴────────────────┴──────────────┴────────────────────┴──────────┴─────────┘
```

complex benchmark:

```
┌─────────┬────────────────┬─────────────┬────────────────────┬──────────┬─────────┐
│ (index) │ Task Name      │ ops/sec     │ Average Time (ns)  │ Margin   │ Samples │
├─────────┼────────────────┼─────────────┼────────────────────┼──────────┼─────────┤
│ 0       │ 'chalk'        │ '1,088,502' │ 918.6933962696653  │ '±2.63%' │ 544253  │
│ 1       │ 'cli-color'    │ '137,864'   │ 7253.475186049178  │ '±1.80%' │ 68933   │
│ 2       │ 'ansi-colors'  │ '571,914'   │ 1748.5130823404193 │ '±2.12%' │ 285958  │
│ 3       │ 'kleur'        │ '1,194,874' │ 836.9080322981199  │ '±2.69%' │ 597438  │
│ 4       │ 'kleur/colors' │ '1,223,643' │ 817.231344258348   │ '±4.51%' │ 612814  │
│ 5       │ 'colorette'    │ '1,604,697' │ 623.1704445320281  │ '±3.55%' │ 802349  │
│ 6       │ 'nanocolors'   │ '1,707,219' │ 585.7478251191258  │ '±0.32%' │ 853610  │
│ 7       │ 'yoctocolors'  │ '1,734,362' │ 576.5806047640162  │ '±1.01%' │ 867182  │
│ 8       │ 'picocolors'   │ '1,806,240' │ 553.6361362441488  │ '±3.55%' │ 903121  │
└─────────┴────────────────┴─────────────┴────────────────────┴──────────┴─────────┘
```

its pretty close now, the complex ops/sec floats around a bit. but we're fastest on the simple ones

in reality there's nothing yocto can do anymore to be faster without literally having the same algo as us

