### PR TITLE
Supress Webpack warning for conditional require

### DIFF
--- a/picocolors.js
+++ b/picocolors.js
@@ -1,11 +1,12 @@
 let argv = process.argv || [],
 	env = process.env
+let tty = require("tty")
 let isColorSupported =
 	!("NO_COLOR" in env || argv.includes("--no-color")) &&
 	("FORCE_COLOR" in env ||
 		argv.includes("--color") ||
 		process.platform === "win32" ||
-		(require != null && require("tty").isatty(1) && env.TERM !== "dumb") ||
+		(tty && tty.isatty(1) && env.TERM !== "dumb") ||
 		"CI" in env)
 
 let formatter =


### PR DESCRIPTION
As stated in #67 some bundlers throw the following error/warning:

` 
⚠ ./node_modules/tailwindcss/node_modules/picocolors/picocolors.js
Critical dependency: require function is used in a way in which dependencies cannot be statically extracted
`

As you can see for me the error came up throuth the tailwindcss module, which i wanted to use inside a NextJS React project with nextjs@rc and react@rc which will become react 19 and nextjs 15 respectively.

NextJS uses Webpack, and Webpack for some reason has a setting called "unknownContextCritical" which checks after conditional require statements, which will then throw errors: https://github.com/webpack/docs/wiki/configuration (search the page after it)

To fix the error, simply move the require outside of the condition, its not the nicest since now the require is executed everytime, i know. But for me this is the only fix, i also created a [patch-packages](https://www.npmjs.com/package/patch-package) patch, see here (only works if you also get the error by using tailwind, otherwise you would need to patch the package yourself):

// patches/tailwindcss++picocolors+1.0.1.patch
```
diff --git a/node_modules/tailwindcss/node_modules/picocolors/picocolors.js b/node_modules/tailwindcss/node_modules/picocolors/picocolors.js
index 8b8a23e..0b7a529 100644
--- a/node_modules/tailwindcss/node_modules/picocolors/picocolors.js
+++ b/node_modules/tailwindcss/node_modules/picocolors/picocolors.js
@@ -1,11 +1,12 @@
 let argv = process.argv || [],
 	env = process.env
+let tty = require("tty")
 let isColorSupported =
 	!("NO_COLOR" in env || argv.includes("--no-color")) &&
 	("FORCE_COLOR" in env ||
 		argv.includes("--color") ||
 		process.platform === "win32" ||
-		(require != null && require("tty").isatty(1) && env.TERM !== "dumb") ||
+		(tty && tty.isatty(1) && env.TERM !== "dumb") ||
 		"CI" in env)
 
 let formatter =
```