### PR TITLE
test: add test (shouldn't overflow when coloring already colored large text)

### DIFF
--- a/tests/test.js
+++ b/tests/test.js
@@ -156,6 +156,16 @@ test("non-string input", () => {
 	assert.equal(pc.red(Infinity), FMT.red[0] + "Infinity" + FMT.red[1])
 })
 
+test("shouldn't overflow when coloring already colored large text", () => {
+  try {
+    pc.blue(pc.red("x").repeat(10000))
+    assert(true)
+  } catch (error){
+    console.error(error)
+    assert(false)
+  }
+})
+
 function test(name, fn) {
 	try {
 		fn()


### PR DESCRIPTION
### Description
- related: #64 

Thanks to above PR, there's no more call stack overflow when coloring already colored long string.

I added some tests to compensate a bit.

I wanted to add tests to the Vite project, but it was pretty tricky, so I made a PR here.

Following's related PR on Vite project.
- https://github.com/vitejs/vite/pull/17729

### As-Is (Test fail)
<img width="664" alt="image" src="https://github.com/user-attachments/assets/5f18af52-5d13-42b7-8574-23364caefa06">

### To-Be (Test success)
<img width="540" alt="image" src="https://github.com/user-attachments/assets/23611a51-eda6-47d6-bf9b-9bc9ab764d0b">
