### PR TITLE
fix: use truthy check for conditional require

### DIFF
--- a/picocolors.js
+++ b/picocolors.js
@@ -5,7 +5,7 @@ let isColorSupported =
 	("FORCE_COLOR" in env ||
 		argv.includes("--color") ||
 		process.platform === "win32" ||
-		(require != null && require("tty").isatty(1) && env.TERM !== "dumb") ||
+		(require && require("tty").isatty(1) && env.TERM !== "dumb") ||
 		"CI" in env)
 
 let formatter =


### PR DESCRIPTION
~Using `globalThis` instead of depending on globals means webpack won't complain at being unable to deal with the dynamic require.~

Using a truthiness check seems to solve the problem

Fixes #67 

cc @alexeyraspopov maybe we can get a new version published if this lands?