### PR TITLE
Fix CI Failures by Adding User-Agent Header to `node:https get method`

### DIFF
--- a/benchmarks/size.js
+++ b/benchmarks/size.js
@@ -6,7 +6,7 @@ let { bold, gray } = require("../picocolors.js")
 
 async function getJSON(url) {
 	return new Promise(resolve => {
-		get(url, { headers: {"user-agent": 'picocolors'} },res => {
+		get(url, { headers: {"user-agent": 'picocolors-size-benchmark'} },res => {
 			let text = ""
 			res.on("data", chunk => {
 				text += chunk

--- a/benchmarks/size.js
+++ b/benchmarks/size.js
@@ -6,7 +6,7 @@ let { bold, gray } = require("../picocolors.js")
 
 async function getJSON(url) {
 	return new Promise(resolve => {
-		get(url, res => {
+		get(url, { headers: {"user-agent": 'picocolors'} },res => {
 			let text = ""
 			res.on("data", chunk => {
 				text += chunk


### PR DESCRIPTION
### Description
- Recent PRs for this repository have been experiencing CI failures.
![image](https://github.com/user-attachments/assets/fd63e596-c6b0-44bf-92a0-a3ca4c5ec188)
- The reason for the CI failure is that `benchmark.yaml` is trying to send requests to the Bundlephobia API. However, their policy has changed, and they are now enforcing a whitelist policy.
- To resolve this issue, I have submitted a PR to the Bundlephobia repository to get API access. You can view the PR [here](https://github.com/styfle/packagephobia/pull/1054)
- According to their [API policy](https://github.com/styfle/packagephobia/blob/main/API.md), requests to the Bundlephobia API must include a "User-Agent" header.
- So I added `"user-agent : picocolors"` as follows.
<img width="560" alt="image" src="https://github.com/user-attachments/assets/984e6705-c2ea-48da-aaa0-ac3778f7708c">
