### PR TITLE
Use `stdout.isTTY`, avoid `tty`. Fixes #67

### DIFF
--- a/picocolors.js
+++ b/picocolors.js
@@ -5,7 +5,7 @@ let isColorSupported =
 	("FORCE_COLOR" in env ||
 		argv.includes("--color") ||
 		process.platform === "win32" ||
-		(require != null && require("tty").isatty(1) && env.TERM !== "dumb") ||
+		(process.stdout && process.stdout.isTTY && env.TERM !== "dumb") ||
 		"CI" in env)
 
 let formatter =


### PR DESCRIPTION
Yet another try to fix #67

https://nodejs.org/api/process.html#a-note-on-process-io
> To check if a stream is connected to a [TTY](https://nodejs.org/api/tty.html#tty) context, check the `isTTY` property.