### PR TITLE
Don't force-enable color if env.CI is set

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -24,7 +24,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install
-      - run: node tests/test.js
+      - run: FORCE_COLOR=1 node tests/test.js
   legacy:
     name: Node v${{ matrix.node-version }} (Legacy)
     runs-on: ubuntu-latest
@@ -40,4 +40,4 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install
-      - run: node tests/test.js
+      - run: FORCE_COLOR=1 node tests/test.js

--- a/picocolors.js
+++ b/picocolors.js
@@ -1,7 +1,7 @@
 let p = process || {}, argv = p.argv || [], env = p.env || {}
 let isColorSupported =
 	!(!!env.NO_COLOR || argv.includes("--no-color")) &&
-	(!!env.FORCE_COLOR || argv.includes("--color") || p.platform === "win32" || ((p.stdout || {}).isTTY && env.TERM !== "dumb") || !!env.CI)
+	(!!env.FORCE_COLOR || argv.includes("--color") || p.platform === "win32" || !!((p.stdout || {}).isTTY && env.TERM !== "dumb"))
 
 let formatter = (open, close, replace = open) =>
 	input => {

--- a/tests/environments.js
+++ b/tests/environments.js
@@ -8,8 +8,8 @@ let CI = process.env.CI
 
 test("ci server", () => {
 	let pc = initModuleEnv({ env: { TERM: "dumb", CI: "1" } })
-	assert.equal(pc.isColorSupported, true)
-	assert.equal(pc.red("text"), pc.createColors(true).red("text"))
+	assert.equal(pc.isColorSupported, false)
+	assert.equal(pc.red("text"), pc.createColors(false).red("text"))
 })
 
 test("arg --color", () => {
@@ -25,7 +25,7 @@ test("env NO_COLOR", () => {
 })
 
 test("env NO_COLOR empty", () => {
-	let pc = initModuleEnv({ env: { NO_COLOR: "", CI } })
+	let pc = initModuleEnv({ env: { FORCE_COLOR: "1", NO_COLOR: "" } })
 	assert.equal(pc.isColorSupported, true)
 	assert.equal(pc.red("text"), pc.createColors(true).red("text"))
 })


### PR DESCRIPTION
Fixes https://github.com/alexeyraspopov/picocolors/issues/79.

Re-fixes https://github.com/alexeyraspopov/picocolors/issues/41, which #87 purported to fix but did not.

In order to replace chalk everywhere, we should match the behavior of the `supports-color` package, which [always disables color if stdout is not a TTY](https://github.com/chalk/supports-color/blob/d4068e70f02d9bf3813fc877bdad7360d8e51d71/index.js#L102-L104). This occurs *before* any CI checks.

This means that GitHub Actions output will once again be uncolored, but this matches how chalk and supports-color behave. It's a bit less pretty, but avoids nasty compatibility issues like I encountered in https://github.com/mochajs/mocha/pull/5471.

Maybe we should change the check to `(p.stdout || {isTTY: true}).isTTY`, for further compatibility?